### PR TITLE
Upgrade action OpenWhisk runtimes.

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -10,8 +10,6 @@ on:
 
 jobs:
   build-and-deploy:
-    env:
-      GPR_USER: mattwelke
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,7 +62,7 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    - run: ./gradlew -Pgpr.user=mattwelke -Pgpr.key=${{ secrets.GPR_TOKEN }} build
+    - run: ./gradlew build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -19,4 +19,4 @@ jobs:
         java-version: '17'
     - uses: gradle/wrapper-validation-action@v1
     - name: Run tests
-      run: ./gradlew -Pgpr.user=mattwelke -Pgpr.key=${{ secrets.GPR_TOKEN }} test
+      run: ./gradlew test

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Bot that tweets (https://twitter.com/PacktBookBot) and logs the Packt free eBook of the day in BigQuery daily.
 
-Uses the Java 18 runtime at https://github.com/mattwelke/apache-openwhisk-runtime-java-18.
+Uses the Java 19 runtime at https://github.com/mattwelke/apache-openwhisk-runtime-java-19.
 
 ## Features
 
@@ -35,7 +35,7 @@ See https://cloud.google.com/iam/docs/overview for more information on GCP IAM.
 
 ## Tech stack & architecture
 
-Written using Java 17, deployed to IBM Cloud Functions using my custom Java 18 runtime from https://github.com/mattwelke/openwhisk-runtime-java-18.
+Written using Java 17, deployed to IBM Cloud Functions using my custom Java 19 runtime from https://github.com/mattwelke/openwhisk-runtime-java-19.
 
 Uses a periodic trigger to begin processing at 12:01am every day. Uses a custom trigger to decouple the data retrieval from use cases for the data. This enables multiple use cases for the fetched data such as tweeting from a Twitter bot and building a public BigQuery dataset on GCP. In the future, this might include publishing to a GCP Pub/Sub topic too.
 

--- a/scripts/build_and_deploy_gcp_data_sharer.sh
+++ b/scripts/build_and_deploy_gcp_data_sharer.sh
@@ -28,5 +28,5 @@ ibmcloud fn namespace target $FUNCTIONS_NAMESPACE
 # Do deploy using action update (aka create or update) command
 ibmcloud fn action update $ACTION_NAME $JAR_PATH \
   --main "com.mattwelke.packtbookbot.GcpDataSharerAction" \
-  --docker "mwelke/openwhisk-runtime-java-18:202301080215" \
+  --docker "mwelke/openwhisk-runtime-java-19:202301090523" \
   --param gcpCreds $2

--- a/scripts/build_and_deploy_title_fetcher.sh
+++ b/scripts/build_and_deploy_title_fetcher.sh
@@ -28,4 +28,4 @@ ibmcloud fn namespace target $FUNCTIONS_NAMESPACE
 # Do deploy using action update (aka create or update) command
 ibmcloud fn action update $ACTION_NAME $JAR_PATH \
   --main "com.mattwelke.packtbookbot.TitleFetcherAction" \
-  --docker "mwelke/openwhisk-runtime-java-18:202301080215"
+  --docker "mwelke/openwhisk-runtime-java-19:202301090523"


### PR DESCRIPTION
Upgrade each action's runtime from the Java 18 runtime to the Java 19 runtime. Each action remains compiled with its origin version of the JDK used to compile it for now, they just run on the newest JVM by running on the newest runtime.