### PR TITLE
Update dependencies

### DIFF
--- a/gcp-data-sharer/build.gradle
+++ b/gcp-data-sharer/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':common')
 
     // https://github.com/googleapis/java-bigquery
-    compileOnly platform('com.google.cloud:libraries-bom:26.7.0')
+    compileOnly platform('com.google.cloud:libraries-bom:26.8.0')
     compileOnly 'com.google.cloud:google-cloud-bigquery'
 }
 

--- a/scripts/build_and_deploy_gcp_data_sharer.sh
+++ b/scripts/build_and_deploy_gcp_data_sharer.sh
@@ -28,5 +28,5 @@ ibmcloud fn namespace target $FUNCTIONS_NAMESPACE
 # Do deploy using action update (aka create or update) command
 ibmcloud fn action update $ACTION_NAME $JAR_PATH \
   --main "com.mattwelke.packtbookbot.GcpDataSharerAction" \
-  --docker "mwelke/openwhisk-runtime-java-19:202302131955" \
+  --docker "mwelke/openwhisk-runtime-java-19:202302200615" \
   --param gcpCreds $2

--- a/scripts/build_and_deploy_title_fetcher.sh
+++ b/scripts/build_and_deploy_title_fetcher.sh
@@ -28,4 +28,4 @@ ibmcloud fn namespace target $FUNCTIONS_NAMESPACE
 # Do deploy using action update (aka create or update) command
 ibmcloud fn action update $ACTION_NAME $JAR_PATH \
   --main "com.mattwelke.packtbookbot.TitleFetcherAction" \
-  --docker "mwelke/openwhisk-runtime-java-19:202302131955"
+  --docker "mwelke/openwhisk-runtime-java-19:202302200615"

--- a/title-fetcher/build.gradle
+++ b/title-fetcher/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':common')
 
     // https://mvnrepository.com/artifact/org.jsoup/jsoup
-    implementation group: 'org.jsoup', name: 'jsoup', version: '1.15.3'
+    compileOnly group: 'org.jsoup', name: 'jsoup', version: '1.15.4'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
 }


### PR DESCRIPTION
Update to latest version of Java 19 runtime, which has jsoup built in now. Update version of GCP library BOM in gcp-data-sharer. Update version of jsoup library in title-fetcher. Change jsoup library from implementation to compileOnly now that it's included in the runtime, to reduce OpenWhisk deployment ZIP file size.